### PR TITLE
Fixed TypeScript glob pattern in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[.ts]
+[*.ts]
 indent_style = space
 indent_size = 2
 charset = utf-8


### PR DESCRIPTION
The wildcard is required for editorconfig, otherwise it doesn't detect the files properly.